### PR TITLE
Fix/allow schema deep validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "behat/behat": "3.*",
         "behat/mink": "*",
-        "behat/mink-extension": "2.0.x-dev",
+        "behat/mink-extension": "~2.0",
         "justinrainbow/json-schema": "*",
         "symfony/property-access": "~2.3"
     },

--- a/features/json.feature
+++ b/features/json.feature
@@ -72,6 +72,51 @@ Feature: Testing JSONContext
             }
             """
 
+
+    Scenario: Json validation deep
+        Given I am on "/json/booking.json"
+        Then the JSON should be invalid according to this schema:
+            """
+            {
+                "type":"object",
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "id": "http://jsonschema.net",
+                "required":false,
+                "properties":{
+                    "Booking": {
+                        "type":"object",
+                        "id": "http://jsonschema.net/Booking",
+                        "required":false
+                    },
+                    "Metadata": {
+                        "type":"object",
+                        "id": "http://jsonschema.net/Metadata",
+                        "required":false,
+                        "properties":{
+                            "First": {
+                                "type":"object",
+                                "id": "http://jsonschema.net/Metadata/First",
+                                "required":false,
+                                "properties":{
+                                    "default_value": {
+                                        "type":"boolean",
+                                        "id": "http://jsonschema.net/Metadata/First/default_value",
+                                        "required":false
+                                    },
+                                    "enabled": {
+                                        "type":"boolean",
+                                        "id": "http://jsonschema.net/Metadata/First/enabled",
+                                        "required":true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+
+
     Scenario: Json contents validation
         Given I am on "/json/imajson.json"
         Then the JSON should be equal to:

--- a/fixtures/www/json/booking.json
+++ b/fixtures/www/json/booking.json
@@ -1,0 +1,12 @@
+{
+    "Booking": {
+        "id": "1",
+        "price": "77.21"
+    }, "Metadata":
+    {
+        "First":  {
+            "bad_property_name": true,
+            "default_value": true
+        }
+    }
+}

--- a/src/Context/BaseContext.php
+++ b/src/Context/BaseContext.php
@@ -16,7 +16,7 @@ abstract class BaseContext extends RawMinkContext implements TranslatableContext
     }
 
     /**
-     * @transform /^(\d+)(?:st|nd|rd|th)?$/
+     * @transform /^(0|[1-9]\d*)(?:st|nd|rd|th)?$/
      */
     public function castToInt($count)
     {

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -7,14 +7,19 @@ use Behat\Gherkin\Node\PyStringNode;
 use Sanpi\Behatch\Json\Json;
 use Sanpi\Behatch\Json\JsonSchema;
 use Sanpi\Behatch\Json\JsonInspector;
+use Sanpi\Behatch\HttpCall\HttpCallResultAware;
+use Sanpi\Behatch\HttpCall\HttpCallResultPool;
 
 class JsonContext extends BaseContext
 {
     private $inspector;
 
-    public function __construct($evaluationMode = 'javascript')
+    private $httpCallResultPool;
+
+    public function __construct($evaluationMode = 'javascript', HttpCallResultPool $httpCallResultPool)
     {
         $this->inspector = new JsonInspector($evaluationMode);
+        $this->httpCallResultPool = $httpCallResultPool;
     }
 
     /**
@@ -204,8 +209,6 @@ class JsonContext extends BaseContext
 
     private function getJson()
     {
-        $content = $this->getSession()->getPage()->getContent();
-
-        return new Json($content);
+        return new Json($this->httpCallResultPool->getResult()->getValue());
     }
 }

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -4,6 +4,7 @@ namespace Sanpi\Behatch\Context;
 
 use Behat\Gherkin\Node\PyStringNode;
 
+use Behat\Mink\Exception\ExpectationException;
 use Sanpi\Behatch\Json\Json;
 use Sanpi\Behatch\Json\JsonSchema;
 use Sanpi\Behatch\Json\JsonInspector;
@@ -156,6 +157,26 @@ class JsonContext extends BaseContext
             $this->getJson(),
             new JsonSchema($schema)
         );
+    }
+
+    /**
+     * @Then the JSON should be invalid according to this schema:
+     */
+    public function theJsonShouldBeInvalidAccordingToThisSchema(PyStringNode $schema)
+    {
+        try {
+            $isValid = $this->inspector->validate(
+                $this->getJson(),
+                new JsonSchema($schema)
+            );
+
+        } catch (\Exception $e) {
+            $isValid = false;
+        }
+
+        if (true === $isValid) {
+            throw new ExpectationException('Expected to receive invalid json, got valid one', $this->getSession(), $e);
+        }
     }
 
     /**

--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -49,8 +49,10 @@ class RestContext extends BaseContext
                 $row['value'] = '@'.rtrim($this->getMinkParameter('files_path'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.substr($row['value'],1);
             }
 
-            $parameters[$row['key']] = $row['value'];
+            $parameters[] = sprintf('%s=%s', $row['key'], $row['value']);
         }
+
+        parse_str(implode('&', $parameters), $parameters);
 
         $client->request($method, $this->locatePath($url), $parameters);
         $client->followRedirects(true);

--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -236,7 +236,7 @@ class RestContext extends BaseContext
 
         if (isset($header[$name])) {
             if (is_array($header[$name])) {
-                $value = $header[$name][0];
+                $value = implode(', ', $header[$name]);
             }
             else {
                 $value = $header[$name];

--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -23,6 +23,8 @@ class RestContext extends BaseContext
 
         $client->request($method, $this->locatePath($url));
         $client->followRedirects(true);
+
+        return $this->getSession()->getPage();
     }
 
     /**
@@ -52,6 +54,8 @@ class RestContext extends BaseContext
 
         $client->request($method, $this->locatePath($url), $parameters);
         $client->followRedirects(true);
+
+        return $this->getSession()->getPage();
     }
 
     /**
@@ -69,6 +73,8 @@ class RestContext extends BaseContext
         $client->request($method, $this->locatePath($url),
             array(), array(), array(), $body->getRaw());
         $client->followRedirects(true);
+
+        return $this->getSession()->getPage();
     }
 
     /**

--- a/src/HttpCall/ContextSupportedVoter.php
+++ b/src/HttpCall/ContextSupportedVoter.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+interface ContextSupportedVoter
+{
+    public function vote(HttpCallResult $httpCallResult);
+}

--- a/src/HttpCall/ContextSupportedVoters.php
+++ b/src/HttpCall/ContextSupportedVoters.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+class ContextSupportedVoters implements ContextSupportedVoter
+{
+    private $voters;
+
+    public function __construct(array $voters = array())
+    {
+        foreach ($voters as $voter) {
+            $this->register($voter);
+        }
+    }
+
+    public function register(ContextSupportedVoter $voter)
+    {
+        $this->voters[] = $voter;
+    }
+
+    public function vote(HttpCallResult $httpCallResult)
+    {
+        foreach ($this->voters as $voter) {
+            if ($voter->vote($httpCallResult)) {
+                if ($voter instanceof FilterableHttpCallResult) {
+                    $httpCallResult->update($voter->filter($httpCallResult));
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/HttpCall/FilterableHttpCallResult.php
+++ b/src/HttpCall/FilterableHttpCallResult.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+interface FilterableHttpCallResult
+{
+    public function filter(HttpCallResult $httpCallResult);
+}

--- a/src/HttpCall/HttpCallListener.php
+++ b/src/HttpCall/HttpCallListener.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+use Behat\Behat\EventDispatcher\Event\StepTested;
+use Behat\Behat\EventDispatcher\Event\AfterStepTested;
+use Behat\Behat\Tester\Result\ExecutedStepResult;
+use Behat\Mink\Mink;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class HttpCallListener implements EventSubscriberInterface
+{
+    private $contextSupportedVoter;
+
+    private $httpCallResultPool;
+
+    private $mink;
+
+    public function __construct(ContextSupportedVoter $contextSupportedVoter, HttpCallResultPool $httpCallResultPool, Mink $mink)
+    {
+        $this->contextSupportedVoter = $contextSupportedVoter;
+        $this->httpCallResultPool = $httpCallResultPool;
+        $this->mink = $mink;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+           StepTested::AFTER => 'afterStep'
+        );
+    }
+
+    public function afterStep(AfterStepTested $event)
+    {
+        $testResult = $event->getTestResult();
+
+        if (!$testResult instanceof ExecutedStepResult) {
+            return;
+        }
+
+        $httpCallResult = new HttpCallResult(
+            $testResult->getCallResult()->getReturn()
+        );
+
+        if ($this->contextSupportedVoter->vote($httpCallResult)) {
+            $this->httpCallResultPool->store($httpCallResult);
+
+            return true;
+        }
+
+        // For now to avoid modification on MinkContext
+        // We add fallback on Mink
+        try {
+            $this->httpCallResultPool->store(
+                new HttpCallResult($this->mink->getSession()->getPage()->getContent())
+            );
+        } catch (\LogicException $e) {
+            // Mink has no response
+        }
+    }
+}

--- a/src/HttpCall/HttpCallResult.php
+++ b/src/HttpCall/HttpCallResult.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+class HttpCallResult
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function update($value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/HttpCall/HttpCallResultPool.php
+++ b/src/HttpCall/HttpCallResultPool.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+class HttpCallResultPool
+{
+    private $result;
+
+    public function store(HttpCallResult $result)
+    {
+        $this->result = $result;
+    }
+
+    public function getResult()
+    {
+        return $this->result;
+    }
+}

--- a/src/HttpCall/HttpCallResultPoolResolver.php
+++ b/src/HttpCall/HttpCallResultPoolResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+use Behat\Behat\Context\Environment\Handler\ContextEnvironmentHandler;
+use Behat\Behat\Context\Argument\ArgumentResolver;
+
+use Sanpi\Behatch\HttpCall\HttpCallResultPool;
+
+class HttpCallResultPoolResolver implements ArgumentResolver
+{
+    private $httpCallResultPool;
+
+    public function __construct(HttpCallResultPool $httpCallResultPool)
+    {
+        $this->httpCallResultPool = $httpCallResultPool;
+    }
+
+    public function resolveArguments(\ReflectionClass $classReflection, array $arguments)
+    {
+        $constructor = $classReflection->getConstructor();
+        if ($constructor !== null) {
+            $parameters = $constructor->getParameters();
+            foreach ($parameters as $parameter) {
+                if (null !== $parameter->getClass() && $parameter->getClass()->name === 'Sanpi\\Behatch\\HttpCall\\HttpCallResultPool') {
+                    $arguments[$parameter->name] = $this->httpCallResultPool;
+                }
+            }
+        }
+        return $arguments;
+    }
+}

--- a/src/HttpCall/RestContextVoter.php
+++ b/src/HttpCall/RestContextVoter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sanpi\Behatch\HttpCall;
+
+class RestContextVoter implements ContextSupportedVoter, FilterableHttpCallResult
+{
+    public function vote(HttpCallResult $httpCallResult)
+    {
+        return $httpCallResult->getValue() instanceof \Behat\Mink\Element\DocumentElement;
+    }
+
+    public function filter(HttpCallResult $httpCallResult)
+    {
+        return $httpCallResult->getValue()->getContent();
+    }
+}

--- a/src/Json/Json.php
+++ b/src/Json/Json.php
@@ -6,7 +6,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class Json
 {
-    private $content;
+    protected $content;
 
     public function __construct($content)
     {

--- a/src/Json/JsonInspector.php
+++ b/src/Json/JsonInspector.php
@@ -16,7 +16,9 @@ class JsonInspector
     public function __construct($evaluationMode)
     {
         $this->evaluationMode = $evaluationMode;
-        $this->accessor = PropertyAccess::createPropertyAccessor();
+        $this->accessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->enableExceptionOnInvalidIndex()
+            ->getPropertyAccessor();
     }
 
     public function evaluate(Json $json, $expression)

--- a/src/Json/JsonSchema.php
+++ b/src/Json/JsonSchema.php
@@ -28,7 +28,7 @@ class JsonSchema extends Json
 
     public function validate(Json $json, Validator $validator)
     {
-        $validator->check($json, $this);
+        $validator->check($json->content, $this->content);
 
         if (!$validator->isValid()) {
             $msg = "JSON does not validate. Violations:".PHP_EOL;

--- a/src/Resources/services/http_call.yml
+++ b/src/Resources/services/http_call.yml
@@ -1,0 +1,23 @@
+services:
+    behatch.http_call.listener:
+        class: Sanpi\Behatch\HttpCall\HttpCallListener
+        arguments: [@behatch.context_supported.voter, @behatch.http_call.result_pool, @mink]
+        tags:
+            - { name: event_dispatcher.subscriber, priority: 0 }
+
+    behatch.http_call.result_pool:
+        class: Sanpi\Behatch\HttpCall\HttpCallResultPool
+
+    behatch.context_supported.voter:
+        class: Sanpi\Behatch\HttpCall\ContextSupportedVoters
+
+    behatch.rest_context_supported.voter:
+        class: Sanpi\Behatch\HttpCall\RestContextVoter
+        tags:
+            - { name: behatch.context_voter }
+
+    behatch.http_call.argument_resolver:
+        class: Sanpi\Behatch\HttpCall\HttpCallResultPoolResolver
+        arguments: [@behatch.http_call.result_pool]
+        tags:
+            - { name: context.argument_resolver }

--- a/tests/units/Json/JsonInspector.php
+++ b/tests/units/Json/JsonInspector.php
@@ -15,7 +15,6 @@ class JsonInspector extends atoum
     {
         $this
             ->given(
-                $accessor = new \Symfony\Component\PropertyAccess\PropertyAccessor,
                 $json = new \mock\Sanpi\Behatch\Json\Json('{}'),
                 $json->getMockController()->read = 'foobar'
             )
@@ -30,7 +29,7 @@ class JsonInspector extends atoum
 
                 ->mock($json)
                     ->call('read')
-                    ->withArguments('foo.bar', $accessor)
+                    ->withArguments('foo.bar')
                     ->once()
         ;
     }
@@ -56,7 +55,6 @@ class JsonInspector extends atoum
     {
         $this
             ->given(
-                $accessor = new \Symfony\Component\PropertyAccess\PropertyAccessor,
                 $json = new \mock\Sanpi\Behatch\Json\Json('{}'),
                 $json->getMockController()->read = 'foobar'
             )
@@ -71,7 +69,7 @@ class JsonInspector extends atoum
 
                 ->mock($json)
                     ->call('read')
-                    ->withArguments('foo.bar', $accessor)
+                    ->withArguments('foo.bar')
                     ->once()
         ;
     }
@@ -80,7 +78,6 @@ class JsonInspector extends atoum
     {
         $this
             ->given(
-                $accessor = new \Symfony\Component\PropertyAccess\PropertyAccessor,
                 $json = new \mock\Sanpi\Behatch\Json\Json('{}'),
                 $json->getMockController()->read = 'foobar'
             )
@@ -95,7 +92,7 @@ class JsonInspector extends atoum
 
                 ->mock($json)
                     ->call('read')
-                    ->withArguments('foo->bar', $accessor)
+                    ->withArguments('foo->bar')
                     ->once()
         ;
     }


### PR DESCRIPTION
Currently the Behat step `And the JSON should be valid according to this schema:` is not validating the json against the given schema. 

Here is a fix + test.
