### PR TITLE
Fix step `the JSON node "Item[10]" should not exist` when node is an array

### DIFF
--- a/features/json.feature
+++ b/features/json.feature
@@ -28,6 +28,8 @@ Feature: Testing JSONContext
         And the JSON node "numbers[3].complexeshizzle" should be equal to "true"
         And the JSON node "numbers[3].so[0]" should be equal to "very"
         And the JSON node "numbers[3].so[1].complicated" should be equal to "indeed"
+        And the JSON node "object[0]" should exist
+        And the JSON node "object[2]" should not exist
 
         And the JSON node "bar" should not exist
 

--- a/fixtures/www/json/imajson.json
+++ b/fixtures/www/json/imajson.json
@@ -8,5 +8,11 @@
       "complexeshizzle": true,
       "so": ["very", {"complicated": "indeed"}]
     }
+  ],
+  "object": [{
+        "id": 1
+      }, {
+        "id":2
+      }
   ]
 }

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -128,12 +128,13 @@ class JsonContext extends BaseContext
         $json = $this->getJson();
 
         $e = null;
+        $actual = null;
         try {
             $actual = $this->getInspector()->evaluate($json, $node);
         } catch (\Exception $e) {
         }
 
-        if ($e === null) {
+        if (null === $e && null !== $actual) {
             throw new \Exception(sprintf("The node '%s' exists and contains '%s'.", $node , json_encode($actual)));
         }
     }


### PR DESCRIPTION
The Json step :

``` gherkin
    And the JSON node "Item[10]" should not exist
```

Was not working when the JSON node was an array.

Fix + Behat tests
