### PR TITLE
Add new JSONContext step validating JSON node against schema

### DIFF
--- a/features/json.feature
+++ b/features/json.feature
@@ -148,3 +148,8 @@ Feature: Testing JSONContext
         Then the response should be in JSON
         And the JSON node "root[0].name" should exist
         And the JSON node "root" should have 2 elements
+
+    Scenario: Json Schema validation
+        Given I am on "/json/imajson.json"
+        And the JSON node "object[0]" should be valid according to the schema "fixtures/www/jsonschema/object.schema.json"
+        And the JSON node "object[1]" should not be valid according to the schema "fixtures/www/jsonschema/object.schema.json"

--- a/fixtures/www/json/imajson.json
+++ b/fixtures/www/json/imajson.json
@@ -10,9 +10,11 @@
     }
   ],
   "object": [{
-        "id": 1
+        "id": 1,
+        "name": "mandatory"
       }, {
         "id":2
+
       }
   ]
 }

--- a/fixtures/www/jsonschema/object.schema.json
+++ b/fixtures/www/jsonschema/object.schema.json
@@ -1,0 +1,14 @@
+{
+    "type":"object",
+    "$schema": "http://json-schema.org/draft-03/schema",
+    "id": "http://jsonschema.net",
+    "required": ["id", "name"],
+    "properties":{
+        "id": {
+            "type":"number"
+        },
+        "name": {
+            "type":"string"
+        }
+    }
+}


### PR DESCRIPTION
In order to ease sub payload and metadata payload validation.

``` gherkin
the JSON node "Item[0]->SubItem" should be valid according to the schema "relative_path.schema.json"
```

And its reciprocity

``` gherkin
the JSON node "Item[0]->SubItem" should not be valid according to the schema "relative_path.schema.json"
```
