### PR TITLE
Convert json_decode() result to array before sizeof

### DIFF
--- a/features/json.feature
+++ b/features/json.feature
@@ -101,3 +101,8 @@ Feature: Testing JSONContext
         Then the response should be in JSON
         And the JSON node "root[0].name" should exist
         And the JSON node "root" should have 2 elements
+
+    Scenario: Check json value with double quote
+        Given I am on "/json/withdoublequote.json"
+        Then the response should be in JSON
+        And the JSON node "foo" should be equal to "A "bar" in a bar"

--- a/fixtures/www/json/withdoublequote.json
+++ b/fixtures/www/json/withdoublequote.json
@@ -1,0 +1,3 @@
+{
+    "foo": "A \"bar\" in a bar"
+}

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -69,7 +69,7 @@ class JsonContext extends BaseContext
 
         $actual = $this->getInspector()->evaluate($json, $node);
 
-        $this->assertSame((integer)$nth, sizeof($actual));
+        $this->assertSame((integer)$nth, sizeof((array) $actual));
     }
 
     /**

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -43,7 +43,7 @@ class JsonContext extends BaseContext
     /**
      * Checks, that given JSON node is equal to given value
      *
-     * @Then /^the JSON node "(?P<node>[^"]*)" should be equal to "(?P<text>[^"]*)"$/
+     * @Then /^the JSON node "(?P<node>[^"]*)" should be equal to "(?P<text>.*)"$/
      */
     public function theJsonNodeShouldBeEqualTo($node, $text)
     {
@@ -75,7 +75,7 @@ class JsonContext extends BaseContext
     /**
      * Checks, that given JSON node contains given value
      *
-     * @Then /^the JSON node "(?P<node>[^"]*)" should contain "(?P<text>[^"]*)"$/
+     * @Then /^the JSON node "(?P<node>[^"]*)" should contain "(?P<text>.*)"$/
      */
     public function theJsonNodeShouldContain($node, $text)
     {
@@ -89,7 +89,7 @@ class JsonContext extends BaseContext
     /**
      * Checks, that given JSON node does not contain given value
      *
-     * @Then /^the JSON node "(?P<node>[^"]*)" should not contain "(?P<text>[^"]*)"$/
+     * @Then /^the JSON node "(?P<node>[^"]*)" should not contain "(?P<text>.*)"$/
      */
     public function theJsonNodeShouldNotContain($node, $text)
     {


### PR DESCRIPTION
Used to count associative array, decoded by json into stdClass.
